### PR TITLE
Reformat code

### DIFF
--- a/lib/crewd_policies/base_policy.rb
+++ b/lib/crewd_policies/base_policy.rb
@@ -10,20 +10,20 @@ module CrewdPolicies
     attr_reader :identity, :record
 
     def initialize(identity, record)
-       @identity = identity
-       @record = record
+      @identity = identity
+      @record = record
     end
 
     def model_class
       @policy_class ||= self.class.name.sub(/Policy$/,'').safe_constantize  # record ? record.class
-     end
+    end
 
     def scope
-       Pundit.policy_scope!(identity, model_class)
-     end
+      Pundit.policy_scope!(identity, model_class)
+    end
 
     class Scope
-       attr_reader :identity, :scope
+      attr_reader :identity, :scope
 
       def initialize(identity, scope)
         @identity = identity

--- a/lib/crewd_policies/base_policy.rb
+++ b/lib/crewd_policies/base_policy.rb
@@ -3,40 +3,40 @@ require 'active_support/core_ext/string/inflections'
 require 'pundit'
 
 module CrewdPolicies
-	# optional
-	class BasePolicy
-		include Policy
+  # optional
+  class BasePolicy
+    include Policy
 
-		attr_reader :identity, :record
+    attr_reader :identity, :record
 
-		def initialize(identity, record)
-	     @identity = identity
-	     @record = record
-		end
+    def initialize(identity, record)
+       @identity = identity
+       @record = record
+    end
 
-		def model_class
-	    @policy_class ||= self.class.name.sub(/Policy$/,'').safe_constantize  # record ? record.class
-	   end
+    def model_class
+      @policy_class ||= self.class.name.sub(/Policy$/,'').safe_constantize  # record ? record.class
+     end
 
-		def scope
-	     Pundit.policy_scope!(identity, model_class)
-	   end
+    def scope
+       Pundit.policy_scope!(identity, model_class)
+     end
 
-		class Scope
-	     attr_reader :identity, :scope
+    class Scope
+       attr_reader :identity, :scope
 
-	    def initialize(identity, scope)
-	      @identity = identity
-	      @scope = scope
-	    end
+      def initialize(identity, scope)
+        @identity = identity
+        @scope = scope
+      end
 
-	    def model_class
-	      @policy_class ||= (self.class.name.sub(/Policy::Scope$/,'').safe_constantize or @scope)
-	    end
+      def model_class
+        @policy_class ||= (self.class.name.sub(/Policy::Scope$/,'').safe_constantize or @scope)
+      end
 
-			def resolve
-				scope
-			end
-		end
-	end
+      def resolve
+        scope
+      end
+    end
+  end
 end

--- a/lib/crewd_policies/jsonapi_resources.rb
+++ b/lib/crewd_policies/jsonapi_resources.rb
@@ -8,32 +8,32 @@
 # end
 
 module CrewdPolicies
-	module JSONAPIResource
+  module JSONAPIResource
 
-		def self.included(aClass)
-	    aClass.send :extend, ClassMethods
-	  end
+    def self.included(aClass)
+      aClass.send :extend, ClassMethods
+    end
 
-		module ClassMethods
+    module ClassMethods
 
-			def inherited(subclass)
-				super
-				attrs = ::Pundit.policy!(nil,subclass._model_class).all_attributes.map(&:to_sym)
-				attrs -= [:id]
-				subclass.send(:attributes, *attrs) unless attrs.empty?
+      def inherited(subclass)
+        super
+        attrs = ::Pundit.policy!(nil,subclass._model_class).all_attributes.map(&:to_sym)
+        attrs -= [:id]
+        subclass.send(:attributes, *attrs) unless attrs.empty?
       end
 
-			def updatable_fields(context)
-				::Pundit.policy!(context[:user],_model).permitted_attributes_for_update.map(&:to_sym)
-		  end
+      def updatable_fields(context)
+        ::Pundit.policy!(context[:user],_model).permitted_attributes_for_update.map(&:to_sym)
+      end
 
-		  def self.creatable_fields(context)
-			  ::Pundit.policy!(context[:user],_model).permitted_attributes_for_create.map(&:to_sym)
-		  end
-		end
+      def self.creatable_fields(context)
+        ::Pundit.policy!(context[:user],_model).permitted_attributes_for_create.map(&:to_sym)
+      end
+    end
 
-		def fetchable_fields
-		  ::Pundit.policy!(context[:user],_model).permitted_attributes_for_read.map(&:to_sym)
-		end
-	end
+    def fetchable_fields
+      ::Pundit.policy!(context[:user],_model).permitted_attributes_for_read.map(&:to_sym)
+    end
+  end
 end

--- a/lib/crewd_policies/model.rb
+++ b/lib/crewd_policies/model.rb
@@ -5,9 +5,9 @@ module CrewdPolicies::Model
   def self.included(aClass)
     aClass.cattr_accessor :roles_rules
     aClass.roles_rules = {}   # [:sales] => [
-                              #               {ability: 'read', fields: [:name,:address]}
-                              #               {ability: 'destroy', allowed: true}
-                              #             ]
+    #               {ability: 'read', fields: [:name,:address]}
+    #               {ability: 'destroy', allowed: true}
+    #             ]
     aClass.send :extend, ClassMethods
   end
 

--- a/lib/crewd_policies/model.rb
+++ b/lib/crewd_policies/model.rb
@@ -2,51 +2,51 @@
 
 module CrewdPolicies::Model
 
-	def self.included(aClass)
-		aClass.cattr_accessor :roles_rules
+  def self.included(aClass)
+    aClass.cattr_accessor :roles_rules
     aClass.roles_rules = {}   # [:sales] => [
-															#               {ability: 'read', fields: [:name,:address]}
-															#               {ability: 'destroy', allowed: true}
-															#             ]
+                              #               {ability: 'read', fields: [:name,:address]}
+                              #               {ability: 'destroy', allowed: true}
+                              #             ]
     aClass.send :extend, ClassMethods
   end
 
-	module ClassMethods
+  module ClassMethods
 
-		# supports different formats : allow <role>, <abilities> => <attributes>
-		#
-		# allow :sales, :write => [:name,:address]   ie. sales can write the name and address fields
-		def allow(aRole,aAbilities)
-			if aRole.is_a? Array
-				aRole.each {|r| allow(r,aAbilities.dup) }
-				return
-			end
-			raise ::StandardExceptions::Http::InternalServerError.new "aRole must be a string or a symbol" unless aRole.is_a?(String) or aRole.is_a?(Symbol)
-			aRole = aRole.to_s
-			raise ::StandardExceptions::Http::InternalServerError.new "aAbilities must be a Hash" unless aAbilities.is_a? Hash # eg. :write => [:name,:address]
+    # supports different formats : allow <role>, <abilities> => <attributes>
+    #
+    # allow :sales, :write => [:name,:address]   ie. sales can write the name and address fields
+    def allow(aRole,aAbilities)
+      if aRole.is_a? Array
+        aRole.each {|r| allow(r,aAbilities.dup) }
+        return
+      end
+      raise ::StandardExceptions::Http::InternalServerError.new "aRole must be a string or a symbol" unless aRole.is_a?(String) or aRole.is_a?(Symbol)
+      aRole = aRole.to_s
+      raise ::StandardExceptions::Http::InternalServerError.new "aAbilities must be a Hash" unless aAbilities.is_a? Hash # eg. :write => [:name,:address]
 
-			role_rules = (self.roles_rules[aRole] ||= [])
-			conditions = {}
-			conditions[:if] = aAbilities.delete(:if) if aAbilities.include?(:if)
-			conditions[:unless] = aAbilities.delete(:unless) if aAbilities.include?(:unless)
-			aAbilities.each do |abilities, fields|
-				abilities = [abilities] unless abilities.is_a?(Array)
-				fields = [fields] unless fields==true or fields.is_a?(Array)
-				abilities = abilities.map{|a| a.to_s}                       # now an array of strings
-				fields = fields.map{|a| a.to_s}.sort unless fields==true    # now an array of strings or true
-				next if fields==[]
-				abilities.each do |a|
-					role_rules << (rule = {})
-					rule[:ability] = a
-					rule[:conditions] = conditions unless conditions.empty?
-					if fields==true  # special "field" value to mean the record or class
-						rule[:allowed] = true
-					else
-						raise ::StandardExceptions::Http::InternalServerError.new "create, destroy and index must have true as a value, not an array of fields" if a=='create' or a=='destroy' or a=='index'
-						rule[:fields] = fields
-					end
-				end
-			end
-		end
-	end
+      role_rules = (self.roles_rules[aRole] ||= [])
+      conditions = {}
+      conditions[:if] = aAbilities.delete(:if) if aAbilities.include?(:if)
+      conditions[:unless] = aAbilities.delete(:unless) if aAbilities.include?(:unless)
+      aAbilities.each do |abilities, fields|
+        abilities = [abilities] unless abilities.is_a?(Array)
+        fields = [fields] unless fields==true or fields.is_a?(Array)
+        abilities = abilities.map{|a| a.to_s}                       # now an array of strings
+        fields = fields.map{|a| a.to_s}.sort unless fields==true    # now an array of strings or true
+        next if fields==[]
+        abilities.each do |a|
+          role_rules << (rule = {})
+          rule[:ability] = a
+          rule[:conditions] = conditions unless conditions.empty?
+          if fields==true  # special "field" value to mean the record or class
+            rule[:allowed] = true
+          else
+            raise ::StandardExceptions::Http::InternalServerError.new "create, destroy and index must have true as a value, not an array of fields" if a=='create' or a=='destroy' or a=='index'
+            rule[:fields] = fields
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/crewd_policies/policy.rb
+++ b/lib/crewd_policies/policy.rb
@@ -4,231 +4,231 @@ require 'pundit'
 require 'standard_exceptions'
 
 module CrewdPolicies
-	module Policy
+  module Policy
 
-		include ::StandardExceptions::Methods
+    include ::StandardExceptions::Methods
 
-		public
+    public
 
-	  attr_reader :identity, :record
+    attr_reader :identity, :record
 
-		# typical pundit/rails methods
+    # typical pundit/rails methods
 
-		def create?   # resource level
-			inner_query_ability(:create)
-		end
+    def create?   # resource level
+      inner_query_ability(:create)
+    end
 
-		def index?
-			inner_query_ability(:index)
-		end
+    def index?
+      inner_query_ability(:index)
+    end
 
-		def show?
-			inner_query_ability(:read)
-		end
+    def show?
+      inner_query_ability(:read)
+    end
 
-		def new?
-			inner_query_ability(:create)
-		end
+    def new?
+      inner_query_ability(:create)
+    end
 
-		def update?
-			inner_query_ability(:write)
-		end
+    def update?
+      inner_query_ability(:write)
+    end
 
-		def edit?
-			inner_query_ability(:write)
-		end
+    def edit?
+      inner_query_ability(:write)
+    end
 
-		def destroy?
-			inner_query_ability(:destroy)
-		end
+    def destroy?
+      inner_query_ability(:destroy)
+    end
 
-		%w(write read create update edit show index).each do |m|
-			define_method "permitted_attributes_for_#{m}" do
-				allowed_attributes(m)
-			end
-		end
+    %w(write read create update edit show index).each do |m|
+      define_method "permitted_attributes_for_#{m}" do
+        allowed_attributes(m)
+      end
+    end
 
-		def all_attributes
-			result = []
-			record_class.roles_rules.each do |role,rules|
-				rules.each do |rule|
-					result |= rule[:fields] if rule[:fields]
-				end
-			end
-			result.sort
-		end
+    def all_attributes
+      result = []
+      record_class.roles_rules.each do |role,rules|
+        rules.each do |rule|
+          result |= rule[:fields] if rule[:fields]
+        end
+      end
+      result.sort
+    end
 
-		def permitted_attributes
-			inner_query_fields('write')
-		end
+    def permitted_attributes
+      inner_query_fields('write')
+    end
 
-		# CREWD permission methods
+    # CREWD permission methods
 
-		def read?
-			inner_query_ability(:read)
-		end
+    def read?
+      inner_query_ability(:read)
+    end
 
-		def write?
-			inner_query_ability(:write)
-		end
+    def write?
+      inner_query_ability(:write)
+    end
 
-		# utility methods
+    # utility methods
 
-		def scope
-			Pundit.policy_scope!(user, record_class)
-		end
+    def scope
+      Pundit.policy_scope!(user, record_class)
+    end
 
-		def unauthorized!(aMessage=nil)
-			raise Pundit::NotAuthorizedError,(aMessage || "must be logged in")
-		end
+    def unauthorized!(aMessage=nil)
+      raise Pundit::NotAuthorizedError,(aMessage || "must be logged in")
+    end
 
-		def forbidden!(aMessage=nil)
-			raise ForbiddenError,(aMessage || "That operation was not allowed")
-		end
+    def forbidden!(aMessage=nil)
+      raise ForbiddenError,(aMessage || "That operation was not allowed")
+    end
 
-		def record_class
-			record.is_a?(Class) ? record : record.class
-		end
+    def record_class
+      record.is_a?(Class) ? record : record.class
+    end
 
-		def allowed?(aAbility,aFields=nil)
-			if aFields
-				pf = allowed_fields(aAbility)
-				if aFields.is_a? Array
-					aFields = aFields.map(&:to_s)
-					return (aFields - pf).empty?
-				else
-					aFields = aFields.to_s
-					return pf.include? aFields
-				end
-			else
-				inner_query_resource(aAbility)
-			end
-		end
+    def allowed?(aAbility,aFields=nil)
+      if aFields
+        pf = allowed_fields(aAbility)
+        if aFields.is_a? Array
+          aFields = aFields.map(&:to_s)
+          return (aFields - pf).empty?
+        else
+          aFields = aFields.to_s
+          return pf.include? aFields
+        end
+      else
+        inner_query_resource(aAbility)
+      end
+    end
 
-		# fields may be attributes or associations
-		def allowed_fields(aAbility)
-			inner_query_fields(aAbility)
-		end
+    # fields may be attributes or associations
+    def allowed_fields(aAbility)
+      inner_query_fields(aAbility)
+    end
 
-	  def allowed_attributes(aAbility)
-		  result = allowed_fields(aAbility)
-		  cls = record_class
-			result.delete_if { |f| cls.reflections.has_key? f } if cls.respond_to? :reflections
-			result
-		end
+    def allowed_attributes(aAbility)
+      result = allowed_fields(aAbility)
+      cls = record_class
+      result.delete_if { |f| cls.reflections.has_key? f } if cls.respond_to? :reflections
+      result
+    end
 
-		def allowed_associations(aAbility=nil)
-		  result = allowed_fields(aAbility)
-		  cls = record_class
-			result.delete_if { |f| !cls.reflections.has_key? f }
-			result
-		end
+    def allowed_associations(aAbility=nil)
+      result = allowed_fields(aAbility)
+      cls = record_class
+      result.delete_if { |f| !cls.reflections.has_key? f }
+      result
+    end
 
-		protected   # internal methods below here
+    protected   # internal methods below here
 
-		def coalesce_field_ability(aAbility)
-			aAbility = aAbility.to_s
-			case aAbility
-				when 'write','read' then aAbility
-				when 'create','update','edit' then 'write'
-				when 'show','index' then 'read'
-				else
-					aAbility
-			end
-		end
+    def coalesce_field_ability(aAbility)
+      aAbility = aAbility.to_s
+      case aAbility
+        when 'write','read' then aAbility
+        when 'create','update','edit' then 'write'
+        when 'show','index' then 'read'
+        else
+          aAbility
+      end
+    end
 
 
-		# what fields does the identity have this ability for ?
-	  def inner_query_fields(aAbility)
-		  internal_server_error! "roles_rules not found on #{record_class.name}, make sure it has \"include CrewdPolicies::Model\"" unless ra = record_class.roles_rules rescue nil
-		  unauthorized! "identity not given" if !identity
-		  internal_server_error! "identity must implement has_role?" if !identity.respond_to? :has_role?
+    # what fields does the identity have this ability for ?
+    def inner_query_fields(aAbility)
+      internal_server_error! "roles_rules not found on #{record_class.name}, make sure it has \"include CrewdPolicies::Model\"" unless ra = record_class.roles_rules rescue nil
+      unauthorized! "identity not given" if !identity
+      internal_server_error! "identity must implement has_role?" if !identity.respond_to? :has_role?
 
-		  ability = coalesce_field_ability(aAbility)
+      ability = coalesce_field_ability(aAbility)
 
-		  # for each role in roles_rules, if identity.has_role?(role) && any conditions pass then merge in fields
-			result = []
-		  ra.each do |role,rules|
-				next unless identity.has_role? role
-				rules.each do |rule| #ab, fields|
-					next unless rule[:ability]==ability
-					next unless eval_conditions rule
-					result |= rule[:fields]
-				end
-			end
-		  result.sort!
-		  result
-	  end
+      # for each role in roles_rules, if identity.has_role?(role) && any conditions pass then merge in fields
+      result = []
+      ra.each do |role,rules|
+        next unless identity.has_role? role
+        rules.each do |rule| #ab, fields|
+          next unless rule[:ability]==ability
+          next unless eval_conditions rule
+          result |= rule[:fields]
+        end
+      end
+      result.sort!
+      result
+    end
 
-		# does the identity have this ability on this record?
-		def inner_query_resource(aAbility)
-			internal_server_error! "aAbility must be a string or a symbol" unless aAbility.is_a?(String) or aAbility.is_a?(Symbol)
-			internal_server_error! "roles_rules not found on #{record_class.name}, make sure it has \"include CrewdPolicies::Model\"" unless ra = record_class.roles_rules rescue nil
-			unauthorized! "identity not given" if !identity
-	    internal_server_error! "identity must implement has_role?" if !identity.respond_to? :has_role?
+    # does the identity have this ability on this record?
+    def inner_query_resource(aAbility)
+      internal_server_error! "aAbility must be a string or a symbol" unless aAbility.is_a?(String) or aAbility.is_a?(Symbol)
+      internal_server_error! "roles_rules not found on #{record_class.name}, make sure it has \"include CrewdPolicies::Model\"" unless ra = record_class.roles_rules rescue nil
+      unauthorized! "identity not given" if !identity
+      internal_server_error! "identity must implement has_role?" if !identity.respond_to? :has_role?
 
-			aAbility = aAbility.to_s
+      aAbility = aAbility.to_s
 
-		  ra.each do |role,rules|
-				next unless identity.has_role? role
-				rules.each do |rule|
-					next unless eval_conditions rule
-					next unless rule[:ability]==aAbility
-					return true if rule[:allowed]==true or rule[:fields].is_a?(Array) && !rule[:fields].empty?
-				end
-		  end
-			false
-		end
+      ra.each do |role,rules|
+        next unless identity.has_role? role
+        rules.each do |rule|
+          next unless eval_conditions rule
+          next unless rule[:ability]==aAbility
+          return true if rule[:allowed]==true or rule[:fields].is_a?(Array) && !rule[:fields].empty?
+        end
+      end
+      false
+    end
 
-		def eval_conditions(aRule)
-			return true unless conds = aRule[:conditions]
-			if_cond = conds[:if]
-			unless_cond = conds[:unless]
+    def eval_conditions(aRule)
+      return true unless conds = aRule[:conditions]
+      if_cond = conds[:if]
+      unless_cond = conds[:unless]
 
-			if_cond = if if_cond.is_a? Symbol
-				send(if_cond)
-			elsif if_cond.is_a? Proc
-				if_cond.call()
-			elsif if_cond==nil
-				true
-			else
-				if_cond
-			end
+      if_cond = if if_cond.is_a? Symbol
+        send(if_cond)
+      elsif if_cond.is_a? Proc
+        if_cond.call()
+      elsif if_cond==nil
+        true
+      else
+        if_cond
+      end
 
-			unless_cond = if unless_cond.is_a? Symbol
-				send(unless_cond)
-			elsif unless_cond.is_a? Proc
-				unless_cond.call()
-			elsif unless_cond==nil
-				false
-			else
-				unless_cond
-			end
+      unless_cond = if unless_cond.is_a? Symbol
+        send(unless_cond)
+      elsif unless_cond.is_a? Proc
+        unless_cond.call()
+      elsif unless_cond==nil
+        false
+      else
+        unless_cond
+      end
 
-			!!if_cond and !unless_cond
-		end
+      !!if_cond and !unless_cond
+    end
 
-		# does the identity have this ability on the record/resource at all?
-		def inner_query_ability(aAbility)
-			internal_server_error! "aAbility must be a string or a symbol" unless aAbility.is_a?(String) or aAbility.is_a?(Symbol)
-			aAbility = aAbility.to_s
+    # does the identity have this ability on the record/resource at all?
+    def inner_query_ability(aAbility)
+      internal_server_error! "aAbility must be a string or a symbol" unless aAbility.is_a?(String) or aAbility.is_a?(Symbol)
+      aAbility = aAbility.to_s
 
-			case aAbility
-				when 'write','read','update','show','edit'
-					inner_query_fields(aAbility).length > 0
-				when 'create','destroy','index'
-					inner_query_resource(aAbility)
-				else
-					internal_server_error! 'this ability is unknown'
-			end
-		end
-	end
-
-	class ForbiddenError < ::StandardExceptions::Http::Forbidden
-		attr_accessor :query, :record, :policy
+      case aAbility
+        when 'write','read','update','show','edit'
+          inner_query_fields(aAbility).length > 0
+        when 'create','destroy','index'
+          inner_query_resource(aAbility)
+        else
+          internal_server_error! 'this ability is unknown'
+      end
+    end
   end
 
-	::Pundit::NotAuthorizedError.class_eval do
-		include ::StandardExceptions::ExceptionInterface
-	end
+  class ForbiddenError < ::StandardExceptions::Http::Forbidden
+    attr_accessor :query, :record, :policy
+  end
+
+  ::Pundit::NotAuthorizedError.class_eval do
+    include ::StandardExceptions::ExceptionInterface
+  end
 end

--- a/lib/crewd_policies/policy.rb
+++ b/lib/crewd_policies/policy.rb
@@ -129,11 +129,11 @@ module CrewdPolicies
     def coalesce_field_ability(aAbility)
       aAbility = aAbility.to_s
       case aAbility
-        when 'write','read' then aAbility
-        when 'create','update','edit' then 'write'
-        when 'show','index' then 'read'
-        else
-          aAbility
+      when 'write','read' then aAbility
+      when 'create','update','edit' then 'write'
+      when 'show','index' then 'read'
+      else
+        aAbility
       end
     end
 
@@ -186,24 +186,24 @@ module CrewdPolicies
       unless_cond = conds[:unless]
 
       if_cond = if if_cond.is_a? Symbol
-        send(if_cond)
-      elsif if_cond.is_a? Proc
-        if_cond.call()
-      elsif if_cond==nil
-        true
-      else
-        if_cond
-      end
+                  send(if_cond)
+                elsif if_cond.is_a? Proc
+                  if_cond.call()
+                elsif if_cond==nil
+                  true
+                else
+                  if_cond
+                end
 
       unless_cond = if unless_cond.is_a? Symbol
-        send(unless_cond)
-      elsif unless_cond.is_a? Proc
-        unless_cond.call()
-      elsif unless_cond==nil
-        false
-      else
-        unless_cond
-      end
+                      send(unless_cond)
+                    elsif unless_cond.is_a? Proc
+                      unless_cond.call()
+                    elsif unless_cond==nil
+                      false
+                    else
+                      unless_cond
+                    end
 
       !!if_cond and !unless_cond
     end
@@ -214,12 +214,12 @@ module CrewdPolicies
       aAbility = aAbility.to_s
 
       case aAbility
-        when 'write','read','update','show','edit'
-          inner_query_fields(aAbility).length > 0
-        when 'create','destroy','index'
-          inner_query_resource(aAbility)
-        else
-          internal_server_error! 'this ability is unknown'
+      when 'write','read','update','show','edit'
+        inner_query_fields(aAbility).length > 0
+      when 'create','destroy','index'
+        inner_query_resource(aAbility)
+      else
+        internal_server_error! 'this ability is unknown'
       end
     end
   end

--- a/spec/crewd_policies_spec.rb
+++ b/spec/crewd_policies_spec.rb
@@ -2,214 +2,214 @@ require 'spec_helper'
 
 context "allow attributes on model then check policy" do
 
-	class IdentityA < Struct.new(:roles)
-		def has_role?(aRole)
-			roles.include? aRole
-		end
-	end
+  class IdentityA < Struct.new(:roles)
+    def has_role?(aRole)
+      roles.include? aRole
+    end
+  end
 
-	context "simple attribute examples" do
+  context "simple attribute examples" do
 
-		let (:junior) { IdentityA.new(%w(junior)) }
-		let (:junior2) { IdentityA.new(%w(junior)) }
-		let (:boss) { IdentityA.new(%w(junior boss)) }
-		let (:master) { IdentityA.new(%w(junior boss master)) }
-		let (:anyone) { IdentityA.new([]) }
+    let (:junior) { IdentityA.new(%w(junior)) }
+    let (:junior2) { IdentityA.new(%w(junior)) }
+    let (:boss) { IdentityA.new(%w(junior boss)) }
+    let (:master) { IdentityA.new(%w(junior boss master)) }
+    let (:anyone) { IdentityA.new([]) }
 
-		class CrewdTestModel
-			include ActiveModel::Model
-			include CrewdPolicies::Model
+    class CrewdTestModel
+      include ActiveModel::Model
+      include CrewdPolicies::Model
 
-			allow :junior, %w(read write) => [:name,:address]
-			allow :junior, index: true
-			allow :junior, read: [:dob]
-			allow :boss, read: [:next_of_kin]
-			allow :boss, %w(create destroy) => true
+      allow :junior, %w(read write) => [:name,:address]
+      allow :junior, index: true
+      allow :junior, read: [:dob]
+      allow :boss, read: [:next_of_kin]
+      allow :boss, %w(create destroy) => true
 
-			allow :boss, transmogrify: []
-			allow :boss, eliminate: true
+      allow :boss, transmogrify: []
+      allow :boss, eliminate: true
 
-			allow :junior, [:cough,:sneeze] => [:desk,:outside]
-		end
+      allow :junior, [:cough,:sneeze] => [:desk,:outside]
+    end
 
-		class CrewdTestModelPolicy < CrewdPolicies::BasePolicy
-		end
+    class CrewdTestModelPolicy < CrewdPolicies::BasePolicy
+    end
 
-		let (:junior_policy) { Pundit.policy!(junior,CrewdTestModel.new) }
-		let (:boss_policy) { Pundit.policy!(boss,CrewdTestModel.new) }
-		let (:master_policy) { Pundit.policy!(master,CrewdTestModel.new) }
-		let (:anyone_policy) { Pundit.policy!(anyone,CrewdTestModel.new) }
+    let (:junior_policy) { Pundit.policy!(junior,CrewdTestModel.new) }
+    let (:boss_policy) { Pundit.policy!(boss,CrewdTestModel.new) }
+    let (:master_policy) { Pundit.policy!(master,CrewdTestModel.new) }
+    let (:anyone_policy) { Pundit.policy!(anyone,CrewdTestModel.new) }
 
-		it "check" do
+    it "check" do
 
-			junior_policy.allowed_attributes(:read).should == %w(address dob name)
-			junior_policy.read?.should == true
-			master_policy.read?.should == true
-			master_policy.permitted_attributes_for_read.should == %w(address dob name next_of_kin)
-			anyone_policy.permitted_attributes_for_read.should == []
-			anyone_policy.read?.should == false
+      junior_policy.allowed_attributes(:read).should == %w(address dob name)
+      junior_policy.read?.should == true
+      master_policy.read?.should == true
+      master_policy.permitted_attributes_for_read.should == %w(address dob name next_of_kin)
+      anyone_policy.permitted_attributes_for_read.should == []
+      anyone_policy.read?.should == false
 
-			junior_policy.allowed?(:transmogrify).should == false
-			boss_policy.allowed?(:transmogrify).should == false
-			master_policy.allowed?(:transmogrify).should == false
+      junior_policy.allowed?(:transmogrify).should == false
+      boss_policy.allowed?(:transmogrify).should == false
+      master_policy.allowed?(:transmogrify).should == false
 
-			junior_policy.allowed?(:eliminate).should == false
-			boss_policy.allowed?(:eliminate).should == true
-			master_policy.allowed?(:eliminate).should == true
+      junior_policy.allowed?(:eliminate).should == false
+      boss_policy.allowed?(:eliminate).should == true
+      master_policy.allowed?(:eliminate).should == true
 
-			junior_policy.allowed?(:cough).should == true
-			junior_policy.allowed?(:sneeze).should == true
-			boss_policy.allowed?(:cough).should == true
-			boss_policy.allowed?(:sneeze).should == true
-			junior_policy.allowed?(:cough,:outside).should == true
-			junior_policy.allowed?(:cough,:desk).should == true
-			junior_policy.allowed?(:cough,[:desk,:outside]).should == true
-			junior_policy.allowed?(:cough,:lunch_room).should == false
+      junior_policy.allowed?(:cough).should == true
+      junior_policy.allowed?(:sneeze).should == true
+      boss_policy.allowed?(:cough).should == true
+      boss_policy.allowed?(:sneeze).should == true
+      junior_policy.allowed?(:cough,:outside).should == true
+      junior_policy.allowed?(:cough,:desk).should == true
+      junior_policy.allowed?(:cough,[:desk,:outside]).should == true
+      junior_policy.allowed?(:cough,:lunch_room).should == false
 
-			junior_policy.allowed_attributes(:cough).should == %w(desk outside)
-			junior_policy.allowed_attributes(:sneeze).should == %w(desk outside)
-		end
+      junior_policy.allowed_attributes(:cough).should == %w(desk outside)
+      junior_policy.allowed_attributes(:sneeze).should == %w(desk outside)
+    end
 
-		it "check resource abilities" do
-			junior_policy.allowed?(:index).should == true
-			junior_policy.allowed?(:create).should == false
-			junior_policy.allowed?(:destroy).should == false
+    it "check resource abilities" do
+      junior_policy.allowed?(:index).should == true
+      junior_policy.allowed?(:create).should == false
+      junior_policy.allowed?(:destroy).should == false
 
-			boss_policy.allowed?(:index).should == true
-			boss_policy.allowed?(:create).should == true
-			boss_policy.allowed?(:destroy).should == true
+      boss_policy.allowed?(:index).should == true
+      boss_policy.allowed?(:create).should == true
+      boss_policy.allowed?(:destroy).should == true
 
-			master_policy.allowed?(:index).should == true
-			master_policy.allowed?(:create).should == true
-			master_policy.allowed?(:destroy).should == true
-		end
-	end
+      master_policy.allowed?(:index).should == true
+      master_policy.allowed?(:create).should == true
+      master_policy.allowed?(:destroy).should == true
+    end
+  end
 
-	context "conditional attribute examples" do
+  context "conditional attribute examples" do
 
-		class IdentityB < Struct.new(:id,:roles)
-			#include ActiveModel::Model
-			include CrewdPolicies::Model
+    class IdentityB < Struct.new(:id,:roles)
+      #include ActiveModel::Model
+      include CrewdPolicies::Model
 
-			def has_role?(aRole)
-				roles.include? aRole
-			end
+      def has_role?(aRole)
+        roles.include? aRole
+      end
 
-			allow :junior, read: %w(name address)
-			allow :junior, write: %w(name address password), if: :is_self?
-			allow :boss, [:read,:write] => [:notes], :if => :is_subordinate?
-			allow :master, [:read,:write] => %w(name address)
-		end
+      allow :junior, read: %w(name address)
+      allow :junior, write: %w(name address password), if: :is_self?
+      allow :boss, [:read,:write] => [:notes], :if => :is_subordinate?
+      allow :master, [:read,:write] => %w(name address)
+    end
 
-		let (:junior) { IdentityB.new(1,%w(junior)) }
-		let (:junior2) { IdentityB.new(2,%w(junior)) }
-		let (:boss) { IdentityB.new(3,%w(junior boss)) }
-		let (:master) { IdentityB.new(4,%w(junior boss master)) }
-		let (:anyone) { IdentityB.new(5,[]) }
+    let (:junior) { IdentityB.new(1,%w(junior)) }
+    let (:junior2) { IdentityB.new(2,%w(junior)) }
+    let (:boss) { IdentityB.new(3,%w(junior boss)) }
+    let (:master) { IdentityB.new(4,%w(junior boss master)) }
+    let (:anyone) { IdentityB.new(5,[]) }
 
-		class IdentityBPolicy < CrewdPolicies::BasePolicy
-			def is_self?
-				@identity==@record
-			end
+    class IdentityBPolicy < CrewdPolicies::BasePolicy
+      def is_self?
+        @identity==@record
+      end
 
-			def is_subordinate?
-				identity.has_role?('master') && !record.has_role?('master') or
-				identity.has_role?('boss') && !record.has_role?('boss')
-			end
-		end
+      def is_subordinate?
+        identity.has_role?('master') && !record.has_role?('master') or
+        identity.has_role?('boss') && !record.has_role?('boss')
+      end
+    end
 
-		it "check" do
-			Pundit.policy!(junior,junior).is_self?.should == true
-			Pundit.policy!(boss,junior).is_subordinate?.should == true
-			Pundit.policy!(master,junior).is_subordinate?.should == true
+    it "check" do
+      Pundit.policy!(junior,junior).is_self?.should == true
+      Pundit.policy!(boss,junior).is_subordinate?.should == true
+      Pundit.policy!(master,junior).is_subordinate?.should == true
 
-			Pundit.policy!(junior,junior).permitted_attributes_for_read.should == %w(address name)
-			Pundit.policy!(junior,junior).permitted_attributes_for_write.should == %w(address name password)
-			Pundit.policy!(junior,junior2).permitted_attributes_for_read.should == %w(address name)
-			Pundit.policy!(junior,junior2).permitted_attributes_for_write.should == []
-			Pundit.policy!(boss,junior).permitted_attributes_for_write.should == %w(notes)
-			Pundit.policy!(boss,boss).permitted_attributes_for_write.should == %w(address name password)
-			Pundit.policy!(boss,master).permitted_attributes_for_write.should == []
-			Pundit.policy!(boss,master).permitted_attributes_for_read.should == %w(address name)
-			Pundit.policy!(master,boss).permitted_attributes_for_write.should == %w(address name notes)
-			Pundit.policy!(master,junior).permitted_attributes_for_write.should == %w(address name notes)
-			Pundit.policy!(master,master).permitted_attributes_for_write.should == %w(address name password)
-		end
-	end
+      Pundit.policy!(junior,junior).permitted_attributes_for_read.should == %w(address name)
+      Pundit.policy!(junior,junior).permitted_attributes_for_write.should == %w(address name password)
+      Pundit.policy!(junior,junior2).permitted_attributes_for_read.should == %w(address name)
+      Pundit.policy!(junior,junior2).permitted_attributes_for_write.should == []
+      Pundit.policy!(boss,junior).permitted_attributes_for_write.should == %w(notes)
+      Pundit.policy!(boss,boss).permitted_attributes_for_write.should == %w(address name password)
+      Pundit.policy!(boss,master).permitted_attributes_for_write.should == []
+      Pundit.policy!(boss,master).permitted_attributes_for_read.should == %w(address name)
+      Pundit.policy!(master,boss).permitted_attributes_for_write.should == %w(address name notes)
+      Pundit.policy!(master,junior).permitted_attributes_for_write.should == %w(address name notes)
+      Pundit.policy!(master,master).permitted_attributes_for_write.should == %w(address name password)
+    end
+  end
 
-	# replace allow_filter with :
-	#
-	# class TestUser < ActiveRecord::Base
-	# 	allow :junior, [:read,:write] => [:name,:address]
-	#   allow :junior, write: :password, if: :is_self
-	#   allow :junior, write: :phone, unless: :cancelled
-	# end
-	#
-	#it "allow_filter enables custom rules despite heirarchy" do
-	# 	class TestUser < ActiveRecord::Base
-	# 		self.table_name = 'users'
-	#
-	# 		include CrewdPolicies::Model
-	#
-	# 		allow :junior, [:read,:write] => [:name,:address]
-	# 		allow :junior, write: :password
-	# 		allow :boss, [:read,:write] => [:notes]
-	# 	end
-	#
-	# 	class TestUserPolicy < KojacBasePolicy
-	# 		allow_filter ability: :write, ring: :boss do |p,fields|   # boss can't write other people's passwords
-	# 			fields -= [:password] if p.user.id != p.record.id
-	# 			fields
-	# 		end
-	# 		allow_filter do |p,fields|   # boss can't write other people's passwords
-	# 			fields = [] if p.user.id != p.record.id and p.user.ring >= p.record.ring and p.user.ring >= Concentric.lookup_ring(:master)
-	# 			fields
-	# 		end
-	# 	end
-	#
-	# 	TestUser.permitted(:junior,:read).should == [:address,:name]
-	# 	TestUser.permitted(:boss,:read).should == [:address,:name,:notes]
-	# 	TestUser.permitted(:junior,:write).should == [:address,:name,:password]
-	# 	TestUser.permitted(:boss,:write).should == [:address,:name,:notes,:password] # permitted is a concentric method!
-	# 	anyone = TestUser.create!(
-	# 		ring: Concentric.lookup_ring(:anyone),
-	# 		first_name: Faker::Name.first_name,
-	# 		last_name:  Faker::Name.last_name,
-	#     email: Faker::Internet.email
-	# 	)
-	# 	junior = TestUser.create!(
-	# 		ring: Concentric.lookup_ring(:junior),
-	# 		first_name: Faker::Name.first_name,
-	# 		last_name:  Faker::Name.last_name,
-	#     email: Faker::Internet.email
-	# 	)
-	# 	junior2 = TestUser.create!(
-	# 		ring: Concentric.lookup_ring(:junior),
-	# 		first_name: Faker::Name.first_name,
-	# 		last_name:  Faker::Name.last_name,
-	#     email: Faker::Internet.email
-	# 	)
-	# 	boss = TestUser.create!(
-	# 		ring: Concentric.lookup_ring(:boss),
-	# 		first_name: Faker::Name.first_name,
-	# 		last_name:  Faker::Name.last_name,
-	#     email: Faker::Internet.email
-	# 	)
-	# 	master = TestUser.create!(
-	# 		ring: Concentric.lookup_ring(:master),
-	# 		first_name: Faker::Name.first_name,
-	# 		last_name:  Faker::Name.last_name,
-	#     email: Faker::Internet.email
-	# 	)
-	# 	TestUserPolicy.new(junior,junior).permitted_attributes(:write).should == [:address,:name,:password]
-	# 	TestUserPolicy.new(junior,junior2).permitted_attributes(:write).should == []
-	# 	TestUserPolicy.new(boss,junior).permitted_attributes(:write).should == [:address,:name,:notes]
-	# 	TestUserPolicy.new(boss,boss).permitted_attributes(:write).should == [:address,:name,:notes,:password]
-	# 	TestUserPolicy.new(boss,master).permitted_attributes(:write).should == []
-	# 	TestUserPolicy.new(master,boss).permitted_attributes(:write).should == [:address,:name,:notes,:password]
-	# 	TestUserPolicy.new(master,junior).permitted_attributes(:write).should == [:address,:name,:notes,:password]
-	# 	TestUserPolicy.new(master,master).permitted_attributes(:write).should == [:address,:name,:notes,:password]
-	# end
+  # replace allow_filter with :
+  #
+  # class TestUser < ActiveRecord::Base
+  #   allow :junior, [:read,:write] => [:name,:address]
+  #   allow :junior, write: :password, if: :is_self
+  #   allow :junior, write: :phone, unless: :cancelled
+  # end
+  #
+  #it "allow_filter enables custom rules despite heirarchy" do
+  #   class TestUser < ActiveRecord::Base
+  #     self.table_name = 'users'
+  #
+  #     include CrewdPolicies::Model
+  #
+  #     allow :junior, [:read,:write] => [:name,:address]
+  #     allow :junior, write: :password
+  #     allow :boss, [:read,:write] => [:notes]
+  #   end
+  #
+  #   class TestUserPolicy < KojacBasePolicy
+  #     allow_filter ability: :write, ring: :boss do |p,fields|   # boss can't write other people's passwords
+  #       fields -= [:password] if p.user.id != p.record.id
+  #       fields
+  #     end
+  #     allow_filter do |p,fields|   # boss can't write other people's passwords
+  #       fields = [] if p.user.id != p.record.id and p.user.ring >= p.record.ring and p.user.ring >= Concentric.lookup_ring(:master)
+  #       fields
+  #     end
+  #   end
+  #
+  #   TestUser.permitted(:junior,:read).should == [:address,:name]
+  #   TestUser.permitted(:boss,:read).should == [:address,:name,:notes]
+  #   TestUser.permitted(:junior,:write).should == [:address,:name,:password]
+  #   TestUser.permitted(:boss,:write).should == [:address,:name,:notes,:password] # permitted is a concentric method!
+  #   anyone = TestUser.create!(
+  #     ring: Concentric.lookup_ring(:anyone),
+  #     first_name: Faker::Name.first_name,
+  #     last_name:  Faker::Name.last_name,
+  #     email: Faker::Internet.email
+  #   )
+  #   junior = TestUser.create!(
+  #     ring: Concentric.lookup_ring(:junior),
+  #     first_name: Faker::Name.first_name,
+  #     last_name:  Faker::Name.last_name,
+  #     email: Faker::Internet.email
+  #   )
+  #   junior2 = TestUser.create!(
+  #     ring: Concentric.lookup_ring(:junior),
+  #     first_name: Faker::Name.first_name,
+  #     last_name:  Faker::Name.last_name,
+  #     email: Faker::Internet.email
+  #   )
+  #   boss = TestUser.create!(
+  #     ring: Concentric.lookup_ring(:boss),
+  #     first_name: Faker::Name.first_name,
+  #     last_name:  Faker::Name.last_name,
+  #     email: Faker::Internet.email
+  #   )
+  #   master = TestUser.create!(
+  #     ring: Concentric.lookup_ring(:master),
+  #     first_name: Faker::Name.first_name,
+  #     last_name:  Faker::Name.last_name,
+  #     email: Faker::Internet.email
+  #   )
+  #   TestUserPolicy.new(junior,junior).permitted_attributes(:write).should == [:address,:name,:password]
+  #   TestUserPolicy.new(junior,junior2).permitted_attributes(:write).should == []
+  #   TestUserPolicy.new(boss,junior).permitted_attributes(:write).should == [:address,:name,:notes]
+  #   TestUserPolicy.new(boss,boss).permitted_attributes(:write).should == [:address,:name,:notes,:password]
+  #   TestUserPolicy.new(boss,master).permitted_attributes(:write).should == []
+  #   TestUserPolicy.new(master,boss).permitted_attributes(:write).should == [:address,:name,:notes,:password]
+  #   TestUserPolicy.new(master,junior).permitted_attributes(:write).should == [:address,:name,:notes,:password]
+  #   TestUserPolicy.new(master,master).permitted_attributes(:write).should == [:address,:name,:notes,:password]
+  # end
 
 
 end

--- a/spec/crewd_policies_spec.rb
+++ b/spec/crewd_policies_spec.rb
@@ -114,7 +114,7 @@ context "allow attributes on model then check policy" do
 
       def is_subordinate?
         identity.has_role?('master') && !record.has_role?('master') or
-        identity.has_role?('boss') && !record.has_role?('boss')
+          identity.has_role?('boss') && !record.has_role?('boss')
       end
     end
 


### PR DESCRIPTION
* Using TAB characters for indentation cause indentation problems in different devices
* Instead we can configure our IDE/Editor to use spaces instead of TABS which will properly add spaces for TABs and will be properly format the code.
* Removed all extra white spaces and re-indent code to use 2 space indentation rule.